### PR TITLE
fix(build): resolve JSX intrinsic element errors by keying mapped rows

### DIFF
--- a/src/routes/task-bandit/index.tsx
+++ b/src/routes/task-bandit/index.tsx
@@ -81,13 +81,13 @@ export default function Page() {
             <div style={{opacity:.6}}>pA</div>
             <div style={{opacity:.6}}>pB</div>
             {session.trials.slice(-10).map(tr => (
-              <>
-                <div key={`t-${tr.t}`}>{tr.t+1}</div>
+              <div key={`row-${tr.t}`} style={{display:'contents'}}>
+                <div>{tr.t + 1}</div>
                 <div>{tr.choice}</div>
                 <div>{tr.reward}</div>
-                <div>{(tr.pA*100).toFixed(0)}%</div>
-                <div>{(tr.pB*100).toFixed(0)}%</div>
-              </>
+                <div>{(tr.pA * 100).toFixed(0)}%</div>
+                <div>{(tr.pB * 100).toFixed(0)}%</div>
+              </div>
             ))}
           </div>
         </section>

--- a/src/routes/task-gonogo/index.tsx
+++ b/src/routes/task-gonogo/index.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useMemo, useState, type ReactNode } from 'react'
+import { useMemo, useState, type ReactNode } from 'react'
 import { estimateRLParams } from '../../lib/api'
 import type { SessionData, Stim, Resp } from './types'
 import { makeSession, nextStim, stepTrial, type GoNoGoConfig } from './state'
@@ -91,13 +91,13 @@ export default function Page() {
             <div style={{opacity:.6}}>correct</div>
             <div style={{opacity:.6}}>reward</div>
             {session.trials.slice(-10).map(tr => (
-              <Fragment key={tr.t}>
+              <div key={`row-${tr.t}`} style={{display:'contents'}}>
                 <div>{tr.t + 1}</div>
                 <div>{tr.stim}</div>
                 <div>{tr.resp}</div>
                 <div>{tr.correct}</div>
                 <div>{tr.reward}</div>
-              </Fragment>
+              </div>
             ))}
           </div>
         </section>


### PR DESCRIPTION
## Summary
- wrap Bandit recent trial rows in a keyed div to satisfy JSX list requirements
- wrap Go/NoGo recent trial rows in a keyed div and remove the now-unnecessary Fragment import

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e012e6a1f08321a7993a05aa7880c5