### PR TITLE
feat(task-delay): delay-credit micro-task

### DIFF
--- a/src/routes/task-delay/index.tsx
+++ b/src/routes/task-delay/index.tsx
@@ -1,0 +1,171 @@
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { estimateRLParams } from '../../lib/api'
+import type { SessionData, Trial } from './types'
+import { makeSession, makeTrial, scoreTrial, applyFeedback, type DelayConfig, dtdIndex } from './state'
+
+export const route = { path: '/tasks/delay', label: 'Delay Credit' } as const
+
+function Stat({ label, value }: { label:string; value: React.ReactNode }) {
+  return (
+    <div className="card" style={{padding:'.6rem .9rem'}}>
+      <div style={{fontSize:12,opacity:.7}}>{label}</div>
+      <div style={{fontWeight:600}}>{value}</div>
+    </div>
+  )
+}
+
+export default function Page() {
+  const cfg: DelayConfig = useMemo(() => ({
+    nTrials: 24,
+    pDelayed: 0.5,
+    fbDelayMs: 1500,
+    pRewardCorrect: 0.9
+  }), [])
+
+  const [session, setSession] = useState<SessionData>(() => makeSession(cfg))
+  const [finished, setFinished] = useState(false)
+  const [current, setCurrent] = useState<Trial>(() => makeTrial(0, cfg))
+  const timerRef = useRef<number | null>(null)
+
+  const t = session.trials.length
+  const nI = session.trials.filter(tr => tr.timing === 'IMMEDIATE').length
+  const nD = session.trials.filter(tr => tr.timing === 'DELAYED').length
+  const accI = (() => {
+    const xs = session.trials.filter(tr => tr.timing === 'IMMEDIATE' && tr.correct != null)
+    return xs.length ? Math.round(100 * xs.reduce((s,t)=>s+(t.correct??0),0)/xs.length) : 0
+  })()
+  const accD = (() => {
+    const xs = session.trials.filter(tr => tr.timing === 'DELAYED' && tr.correct != null)
+    return xs.length ? Math.round(100 * xs.reduce((s,t)=>s+(t.correct??0),0)/xs.length) : 0
+  })()
+  const dtd = dtdIndex(session)
+
+  // cleanup feedback timers on unmount
+  useEffect(() => () => { if (timerRef.current) window.clearTimeout(timerRef.current) }, [])
+
+  function respond(resp: 0|1) {
+    if (finished) return
+    // score current trial
+    const scored = scoreTrial(current, resp, cfg)
+    let nextSession: SessionData = { ...session, trials: [...session.trials, scored] }
+    setSession(nextSession)
+
+    // schedule or show feedback
+    if (scored.timing === 'IMMEDIATE') {
+      nextSession = applyFeedback(nextSession, scored.t)
+      setSession(nextSession)
+    } else {
+      timerRef.current = window.setTimeout(() => {
+        setSession(s => applyFeedback(s, scored.t))
+      }, cfg.fbDelayMs) as unknown as number
+    }
+
+    // next trial or finish
+    const nextT = scored.t + 1
+    if (nextT >= cfg.nTrials) {
+      nextSession.finishedAt = Date.now()
+      setSession(nextSession)
+      setFinished(true)
+    } else {
+      setCurrent(makeTrial(nextT, cfg))
+    }
+  }
+
+  function reset() {
+    if (timerRef.current) window.clearTimeout(timerRef.current)
+    const fresh = makeSession(cfg)
+    setSession(fresh)
+    setCurrent(makeTrial(0, cfg))
+    setFinished(false)
+  }
+
+  const params = finished ? estimateRLParams(session) : null
+
+  return (
+    <div className="grid">
+      <section className="card">
+        <h1>Delay-Credit</h1>
+        <p>
+          Choose the category that matches the stimulus (0/1). Feedback is <strong>Immediate</strong> or <strong>Delayed</strong>.
+          We compare accuracy to estimate a simple DTD index (delay-credit cost).
+        </p>
+        <div style={{display:'flex',gap:'.5rem',flexWrap:'wrap',marginTop:'.5rem'}}>
+          <Stat label="Trial" value={`${t} / ${cfg.nTrials}`} />
+          <Stat label="Immediate trials" value={nI} />
+          <Stat label="Delayed trials" value={nD} />
+          <Stat label="Acc (Immediate)" value={`${accI}%`} />
+          <Stat label="Acc (Delayed)" value={`${accD}%`} />
+          <Stat label="DTD index" value={dtd.toFixed(2)} />
+          <Stat label="Total reward" value={session.totalReward} />
+        </div>
+
+        {!finished ? (
+          <>
+            <div className="card" style={{marginTop:'1rem', textAlign:'center'}}>
+              <div style={{fontSize:14,opacity:.7}}>Stimulus</div>
+              <div style={{fontSize:40, fontWeight:800}}>{current.stim}</div>
+              <div style={{marginTop:'.5rem', fontSize:12, opacity:.7}}>
+                Feedback: {current.timing === 'IMMEDIATE' ? 'Immediate' : `Delayed (${cfg.fbDelayMs} ms)`}
+              </div>
+            </div>
+            <div style={{display:'flex', gap:'1rem', marginTop:'1rem'}}>
+              <button className="btn primary" onClick={() => respond(0)} aria-label="Choose 0">Choose 0</button>
+              <button className="btn" onClick={() => respond(1)} aria-label="Choose 1">Choose 1</button>
+            </div>
+          </>
+        ) : (
+          <div style={{display:'flex', gap:'.5rem', marginTop:'1rem', alignItems:'center'}}>
+            <button className="btn primary" onClick={reset}>Play again</button>
+            <small style={{opacity:.7}}>Finished in {(session.finishedAt! - session.startedAt)/1000}s</small>
+          </div>
+        )}
+      </section>
+
+      {t > 0 && (
+        <section className="card">
+          <h2>Recent trials</h2>
+          <div style={{display:'grid', gridTemplateColumns:'auto auto auto auto auto auto', gap:'.5rem', fontSize:14}}>
+            <div style={{opacity:.6}}>t</div>
+            <div style={{opacity:.6}}>timing</div>
+            <div style={{opacity:.6}}>stim</div>
+            <div style={{opacity:.6}}>resp</div>
+            <div style={{opacity:.6}}>correct</div>
+            <div style={{opacity:.6}}>reward</div>
+            {session.trials.slice(-10).map(tr => (
+              <div key={`row-${tr.t}`} style={{display:'contents'}}>
+                <div>{tr.t + 1}</div>
+                <div>{tr.timing}</div>
+                <div>{tr.stim}</div>
+                <div>{tr.resp ?? '—'}</div>
+                <div>{tr.correct ?? '—'}</div>
+                <div>{tr.reward ?? '—'}</div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {finished && params && (
+        <section className="card">
+          <h2>Estimated RL parameters (stub)</h2>
+          <p>From <code>estimateRLParams(session)</code>. Real MLE arrives in a later PR.</p>
+          <ul>
+            <li><strong>alphaPlus</strong>: {params.alphaPlus}</li>
+            <li><strong>alphaMinus</strong>: {params.alphaMinus}</li>
+            <li><strong>beta</strong>: {params.beta}</li>
+            <li><strong>kappa</strong>: {params.kappa}</li>
+          </ul>
+        </section>
+      )}
+
+      <section className="card">
+        <h2>Notes</h2>
+        <ul>
+          <li>Self-contained route; no shared-file edits.</li>
+          <li><strong>DTD index</strong> = Acc(Immediate) − Acc(Delayed).</li>
+          <li>Feedback delay is simulated; later we can add timers/animations.</li>
+        </ul>
+      </section>
+    </div>
+  )
+}

--- a/src/routes/task-delay/state.ts
+++ b/src/routes/task-delay/state.ts
@@ -1,0 +1,50 @@
+import type { SessionData, Trial, FeedbackTiming } from './types'
+
+export type DelayConfig = {
+  nTrials: number            // total trials
+  pDelayed: number           // probability of delayed feedback (rest immediate)
+  fbDelayMs: number          // delay in ms for delayed feedback
+  pRewardCorrect: number     // probability of reward when correct
+}
+
+function coin(p:number, rnd:()=>number=Math.random){ return rnd() < p }
+
+export function makeSession(cfg: DelayConfig): SessionData {
+  return {
+    task: 'delay-credit',
+    trials: [],
+    startedAt: Date.now(),
+    totalReward: 0,
+    meta: { ...cfg }
+  }
+}
+
+export function makeTrial(t:number, cfg: DelayConfig): Trial {
+  const timing: FeedbackTiming = coin(cfg.pDelayed) ? 'DELAYED' : 'IMMEDIATE'
+  const stim = coin(0.5) ? 1 : 0
+  return { t, timing, stim, ts: Date.now() }
+}
+
+export function scoreTrial(tr: Trial, resp: 0|1, cfg: DelayConfig): Trial {
+  const correct: 0|1 = (resp === tr.stim) ? 1 : 0
+  const reward: 0|1 = correct && coin(cfg.pRewardCorrect) ? 1 : 0
+  return { ...tr, resp, correct, reward }
+}
+
+export function applyFeedback(session: SessionData, idx: number): SessionData {
+  const trials = session.trials.slice()
+  const tr = trials[idx]
+  if (!tr || tr.fbShown) return session
+  trials[idx] = { ...tr, fbShown: true, fbTs: Date.now() }
+  const totalReward = trials.reduce((s, x) => s + (x.reward ?? 0), 0)
+  return { ...session, trials, totalReward }
+}
+
+export function dtdIndex(session: SessionData): number {
+  // simple accuracy drop: acc_immediate - acc_delayed
+  const imm = session.trials.filter(t => t.timing === 'IMMEDIATE' && t.correct != null)
+  const del = session.trials.filter(t => t.timing === 'DELAYED' && t.correct != null)
+  const accI = imm.length ? imm.reduce((s,t)=>s+(t.correct??0),0)/imm.length : 0
+  const accD = del.length ? del.reduce((s,t)=>s+(t.correct??0),0)/del.length : 0
+  return accI - accD
+}

--- a/src/routes/task-delay/types.ts
+++ b/src/routes/task-delay/types.ts
@@ -1,0 +1,22 @@
+export type FeedbackTiming = 'IMMEDIATE' | 'DELAYED'
+
+export type Trial = {
+  t: number
+  timing: FeedbackTiming
+  stim: number           // 0/1 category for a trivial discrimination
+  resp?: 0 | 1
+  correct?: 0 | 1
+  reward?: 0 | 1
+  fbShown?: boolean
+  fbTs?: number
+  ts: number
+}
+
+export type SessionData = {
+  task: 'delay-credit'
+  trials: Trial[]
+  startedAt: number
+  finishedAt?: number
+  totalReward: number
+  meta: { nTrials:number; pDelayed:number; fbDelayMs:number; pRewardCorrect:number }
+}


### PR DESCRIPTION
## Summary
- add delay-credit task route implementing immediate vs delayed feedback micro-task
- track session state locally, compute accuracy stats and DTD index, and show recent trials table
- surface RL parameter stub estimates once session finishes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0159314f48321bfafd4550258bb02