### PR TITLE
feat(task-gating): WM Update vs Ignore micro-task

### DIFF
--- a/src/routes/task-gating/index.tsx
+++ b/src/routes/task-gating/index.tsx
@@ -1,0 +1,158 @@
+import { useMemo, useState } from 'react'
+import { estimateRLParams } from '../../lib/api'
+import type { MiniTrial, SessionData } from './types'
+import { makeSession, makeMiniTrial, scoreMiniTrial, aggregate, type GatingConfig } from './state'
+
+export const route = { path: '/tasks/gating', label: 'WM Gating' } as const
+
+function Stat({ label, value }: { label:string; value: React.ReactNode }) {
+  return (
+    <div className="card" style={{padding:'.6rem .9rem'}}>
+      <div style={{fontSize:12,opacity:.7}}>{label}</div>
+      <div style={{fontWeight:600}}>{value}</div>
+    </div>
+  )
+}
+
+function StepView({ mt }: { mt: MiniTrial }) {
+  return (
+    <div className="card" style={{display:'grid', gridTemplateColumns:'auto auto auto', gap:'.5rem'}}>
+      <div style={{opacity:.7}}>idx</div>
+      <div style={{opacity:.7}}>cue</div>
+      <div style={{opacity:.7}}>val</div>
+      {mt.steps.map(s => (
+        <div key={`row-${s.idx}`} style={{display:'contents'}}>
+          <div>{s.idx+1}</div>
+          <div>{s.cue === 'UPDATE' ? '⭐ UPDATE' : '• IGNORE'}</div>
+          <div>{s.val}</div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default function Page() {
+  const cfg: GatingConfig = useMemo(() => ({
+    nTrials: 12,
+    seqLen: 4,
+    pUpdate: 0.5
+  }), [])
+
+  const [session, setSession] = useState<SessionData>(() => makeSession(cfg))
+  const [current, setCurrent] = useState<MiniTrial>(() => makeMiniTrial(0, cfg))
+  const [finished, setFinished] = useState(false)
+
+  const t = session.trials.length
+  const { acc, updFail, ignIntr, gatingNoise } = aggregate(session)
+
+  function answer(resp: 0|1) {
+    if (finished) return
+    const scored = scoreMiniTrial(current, resp)
+    const nextSession: SessionData = { ...session, trials: [...session.trials, scored] }
+    const nextT = scored.t + 1
+    if (nextT >= cfg.nTrials) {
+      nextSession.finishedAt = Date.now()
+      setSession(nextSession)
+      setFinished(true)
+    } else {
+      setSession(nextSession)
+      setCurrent(makeMiniTrial(nextT, cfg))
+    }
+  }
+
+  function nextSequence() {
+    // convenience: skip answering and force incorrect (rarely used; we keep UI simple)
+    answer( (Math.random() < 0.5 ? 0 : 1) as 0|1 )
+  }
+
+  function reset() {
+    const fresh = makeSession(cfg)
+    setSession(fresh)
+    setCurrent(makeMiniTrial(0, cfg))
+    setFinished(false)
+  }
+
+  const params = finished ? estimateRLParams(session) : null
+
+  return (
+    <div className="grid">
+      <section className="card">
+        <h1>WM Update vs Ignore</h1>
+        <p>
+          Read the sequence: ⭐ means <strong>UPDATE WM</strong> to the shown value;<br/>
+          • means <strong>IGNORE</strong> (distractor). After the sequence, answer which value is held in WM.
+        </p>
+        <div style={{display:'flex',gap:'.5rem',flexWrap:'wrap',marginTop:'.5rem'}}>
+          <Stat label="Mini-trial" value={`${t} / ${cfg.nTrials}`} />
+          <Stat label="Accuracy" value={`${Math.round(acc*100)}%`} />
+          <Stat label="Update failure" value={`${Math.round(updFail*100)}%`} />
+          <Stat label="Ignore intrusion" value={`${Math.round(ignIntr*100)}%`} />
+          <Stat label="Gating Noise Index" value={gatingNoise.toFixed(2)} />
+        </div>
+      </section>
+
+      <StepView mt={current} />
+
+      {!finished ? (
+        <section className="card">
+          <h2>Probe</h2>
+          <p>Which value is currently in WM?</p>
+          <div style={{display:'flex', gap:'1rem'}}>
+            <button className="btn primary" onClick={() => answer(0)} aria-label="Answer 0">Answer 0</button>
+            <button className="btn" onClick={() => answer(1)} aria-label="Answer 1">Answer 1</button>
+          </div>
+          <p style={{opacity:.7, marginTop:'.5rem'}}>Or <button className="btn" onClick={nextSequence}>skip (random)</button> to move on.</p>
+        </section>
+      ) : (
+        <section className="card" style={{display:'flex', gap:'.75rem', alignItems:'center'}}>
+          <button className="btn primary" onClick={reset}>Play again</button>
+          <small style={{opacity:.7}}>Finished in {(session.finishedAt! - session.startedAt)/1000}s</small>
+        </section>
+      )}
+
+      {t > 0 && (
+        <section className="card">
+          <h2>Recent mini-trials</h2>
+          <div style={{display:'grid', gridTemplateColumns:'auto auto auto auto auto', gap:'.5rem', fontSize:14}}>
+            <div style={{opacity:.6}}>t</div>
+            <div style={{opacity:.6}}>seqLen</div>
+            <div style={{opacity:.6}}>updOps</div>
+            <div style={{opacity:.6}}>ignOps</div>
+            <div style={{opacity:.6}}>correct</div>
+            {session.trials.slice(-10).map(mt => (
+              <div key={`row-${mt.t}`} style={{display:'contents'}}>
+                <div>{mt.t + 1}</div>
+                <div>{mt.steps.length}</div>
+                <div>{mt.updateOps}</div>
+                <div>{mt.ignoreOps}</div>
+                <div>{mt.correct ?? '—'}</div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {finished && params && (
+        <section className="card">
+          <h2>Estimated RL parameters (stub)</h2>
+          <p>From <code>estimateRLParams(session)</code>. Real MLE will arrive in a later PR.</p>
+          <ul>
+            <li><strong>alphaPlus</strong>: {params.alphaPlus}</li>
+            <li><strong>alphaMinus</strong>: {params.alphaMinus}</li>
+            <li><strong>beta</strong>: {params.beta}</li>
+            <li><strong>kappa</strong>: {params.kappa}</li>
+          </ul>
+        </section>
+      )}
+
+      <section className="card">
+        <h2>Notes</h2>
+        <ul>
+          <li>Self-contained route; auto-registers via discovery.</li>
+          <li><strong>Gating Noise Index</strong> = mean(Update failure, Ignore intrusion).</li>
+          <li>Later we can add timing pressure and distractor salience.</li>
+        </ul>
+      </section>
+    </div>
+  )
+}

--- a/src/routes/task-gating/state.ts
+++ b/src/routes/task-gating/state.ts
@@ -1,0 +1,84 @@
+import type { Cue, MiniTrial, SessionData, Step } from './types'
+
+export type GatingConfig = {
+  nTrials: number     // number of mini-trials
+  seqLen: number      // number of cue–value steps per mini-trial
+  pUpdate: number     // probability a given step is UPDATE vs IGNORE
+}
+
+function coin(p:number, rnd:()=>number=Math.random){ return rnd() < p }
+function bit(rnd:()=>number=Math.random): 0|1 { return coin(0.5, rnd) ? 1 : 0 }
+
+export function makeSession(cfg: GatingConfig): SessionData {
+  return {
+    task: 'wm-gating',
+    trials: [],
+    startedAt: Date.now(),
+    meta: { ...cfg }
+  }
+}
+
+// Build a sequence where at least one UPDATE occurs to define a WM target.
+export function makeMiniTrial(t: number, cfg: GatingConfig): MiniTrial {
+  const steps: Step[] = []
+  let hasUpdate = false
+  for (let i=0; i<cfg.seqLen; i++) {
+    const cue: Cue = coin(cfg.pUpdate) ? 'UPDATE' : 'IGNORE'
+    const val = bit()
+    if (cue === 'UPDATE') hasUpdate = true
+    steps.push({ idx: i, cue, val })
+  }
+  if (!hasUpdate) {
+    // Guarantee at least one UPDATE by forcing the last step to UPDATE
+    const last = steps[steps.length - 1]
+    steps[steps.length - 1] = { ...last, cue: 'UPDATE' }
+  }
+  return {
+    t, steps,
+    updateOps: steps.filter(s => s.cue === 'UPDATE').length,
+    ignoreOps: steps.filter(s => s.cue === 'IGNORE').length,
+    updateFailures: 0,
+    ignoreIntrusions: 0
+  }
+}
+
+// Compute the ground-truth WM after the sequence (last UPDATE value).
+export function computeWmTarget(steps: Step[]): 0|1 {
+  let wm: 0|1 = 0
+  let seen = false
+  for (const s of steps) {
+    if (s.cue === 'UPDATE') { wm = s.val; seen = true }
+  }
+  if (!seen) wm = steps[steps.length-1].val // fallback (shouldn’t happen due to fix above)
+  return wm
+}
+
+export function scoreMiniTrial(mt: MiniTrial, resp: 0|1): MiniTrial {
+  const wmTarget = computeWmTarget(mt.steps)
+  const correct: 0|1 = resp === wmTarget ? 1 : 0
+  // Diagnostics:
+  // - update failure: final answer != last UPDATE
+  const updateFailures = correct ? 0 : 1
+  // - ignore intrusion: treat as 1 if the last step was IGNORE and its val == resp but != wmTarget
+  const last = mt.steps[mt.steps.length - 1]
+  const ignoreIntrusions = (!correct && last.cue === 'IGNORE' && resp === last.val && last.val !== wmTarget) ? 1 : 0
+
+  return {
+    ...mt,
+    probeResp: resp,
+    correct,
+    wmTarget,
+    updateFailures,
+    ignoreIntrusions,
+  }
+}
+
+// Aggregate metrics
+export function aggregate(session: SessionData) {
+  const n = session.trials.length || 1
+  const acc = session.trials.reduce((s, t) => s + (t.correct ?? 0), 0) / n
+  const updFail = session.trials.reduce((s, t) => s + (t.updateFailures ?? 0), 0) / n
+  const ignIntr = session.trials.reduce((s, t) => s + (t.ignoreIntrusions ?? 0), 0) / n
+  const gatingNoise = (updFail + ignIntr) / 2
+  return { acc, updFail, ignIntr, gatingNoise }
+}

--- a/src/routes/task-gating/types.ts
+++ b/src/routes/task-gating/types.ts
@@ -1,0 +1,28 @@
+export type Cue = 'UPDATE' | 'IGNORE'
+
+export type Step = {
+  idx: number
+  cue: Cue
+  val: 0 | 1
+}
+
+export type MiniTrial = {
+  t: number
+  steps: Step[]             // sequence of cue–value pairs
+  probeResp?: 0 | 1         // user response at probe
+  correct?: 0 | 1           // correctness at probe
+  wmTarget?: 0 | 1          // ground-truth WM after sequence
+  // Diagnostics
+  updateOps: number         // count of UPDATE cues
+  ignoreOps: number         // count of IGNORE cues
+  updateFailures: number    // times user final answer mismatched last UPDATE (proxy)
+  ignoreIntrusions: number  // whether last IGNORE value wrongly appears to dominate (proxy)
+}
+
+export type SessionData = {
+  task: 'wm-gating'
+  trials: MiniTrial[]
+  startedAt: number
+  finishedAt?: number
+  meta: { nTrials:number; seqLen:number; pUpdate:number }
+}


### PR DESCRIPTION
## Summary
- add WM gating task route with local state for mini-trials and probe responses
- implement session utilities to generate trials, score responses, and aggregate gating metrics
- surface task UI with accuracy diagnostics, gating noise index, and RL parameter stub output

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e01778d21c8321ab9817f280169cbf