### PR TITLE
feat(task-effort): effort trade-off choices

### DIFF
--- a/src/routes/task-effort/index.tsx
+++ b/src/routes/task-effort/index.tsx
@@ -1,0 +1,141 @@
+import { useMemo, useState } from 'react'
+import { estimateRLParams } from '../../lib/api'
+import type { SessionData } from './types'
+import { makeSession, step, type EffortConfig, getOffer } from './state'
+
+export const route = { path: '/tasks/effort', label: 'Effort' } as const
+
+function Stat({ label, value }: { label:string; value: React.ReactNode }) {
+  return (
+    <div className="card" style={{padding:'.6rem .9rem'}}>
+      <div style={{fontSize:12,opacity:.7}}>{label}</div>
+      <div style={{fontWeight:600}}>{value}</div>
+    </div>
+  )
+}
+
+export default function Page() {
+  const cfg: EffortConfig = useMemo(() => ({ nTrials: 8 }), [])
+  const [session, setSession] = useState<SessionData>(() => makeSession(cfg))
+  const [offer, setOffer] = useState(() => getOffer(0))
+  const finished = !!session.finishedAt
+  const t = session.trials.length
+
+  const wMid = (session.wLower + session.wUpper) / 2
+  const conf = Math.max(0, 1 - Math.min(1, session.wUpper - session.wLower)) // crude confidence from interval width
+
+  function choose(choice: 'EASY'|'HARD') {
+    if (finished) return
+    const { session: nextS, nextOffer } = step(session, choice, cfg)
+    setSession(nextS)
+    if (nextOffer) setOffer(nextOffer)
+  }
+
+  function reset() {
+    const fresh = makeSession(cfg)
+    setSession(fresh)
+    setOffer(getOffer(0))
+  }
+
+  const params = finished ? estimateRLParams(session) : null
+
+  return (
+    <div className="grid">
+      <section className="card">
+        <h1>Effort Trade-off</h1>
+        <p>
+          Pick between <strong>Easy</strong> (low effort, low reward) and <strong>Hard</strong> (higher effort, higher reward).
+          We estimate your current <em>effort-cost weight</em> <code>w_E</code>.
+        </p>
+        <div style={{display:'flex',gap:'.5rem',flexWrap:'wrap',marginTop:'.5rem'}}>
+          <Stat label="Offer" value={`${t} / ${cfg.nTrials}`} />
+          <Stat label="w<sub>Lower</sub>" value={session.wLower.toFixed(2)} />
+          <Stat label="w<sub>Upper</sub>" value={session.wUpper.toFixed(2)} />
+          <Stat label="ŵ (mid)" value={wMid.toFixed(2)} />
+          <Stat label="Confidence" value={`${Math.round(conf*100)}%`} />
+        </div>
+      </section>
+
+      {!finished && (
+        <section className="card">
+          <h2>Current offer</h2>
+          <div className="grid" style={{gridTemplateColumns:'1fr 1fr', gap:'1rem'}}>
+            <div className="card">
+              <h3>Easy</h3>
+              <p>Reward: <strong>{offer.Re}</strong></p>
+              <p>Effort: <strong>{offer.Ee}</strong></p>
+              <button className="btn" onClick={() => choose('EASY')} aria-label="Choose Easy">Choose Easy</button>
+            </div>
+            <div className="card">
+              <h3>Hard</h3>
+              <p>Reward: <strong>{offer.Rh}</strong></p>
+              <p>Effort: <strong>{offer.Eh}</strong></p>
+              <button className="btn primary" onClick={() => choose('HARD')} aria-label="Choose Hard">Choose Hard</button>
+            </div>
+          </div>
+          <p style={{opacity:.7, marginTop:'.5rem'}}>
+            Indifference threshold for this offer: <code>w* = {(offer.wStar).toFixed(2)}</code>
+          </p>
+        </section>
+      )}
+
+      {t > 0 && (
+        <section className="card">
+          <h2>Recent choices</h2>
+          <div style={{display:'grid', gridTemplateColumns:'auto auto auto auto auto auto', gap:'.5rem', fontSize:14}}>
+            <div style={{opacity:.6}}>t</div>
+            <div style={{opacity:.6}}>Re</div>
+            <div style={{opacity:.6}}>Ee</div>
+            <div style={{opacity:.6}}>Rh</div>
+            <div style={{opacity:.6}}>Eh</div>
+            <div style={{opacity:.6}}>choice</div>
+            {session.trials.slice(-10).map(tr => (
+              <div key={`row-${tr.t}`} style={{display:'contents'}}>
+                <div>{tr.t + 1}</div>
+                <div>{tr.Re}</div>
+                <div>{tr.Ee}</div>
+                <div>{tr.Rh}</div>
+                <div>{tr.Eh}</div>
+                <div>{tr.choice ?? '—'}</div>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {finished && (
+        <section className="card">
+          <h2>Estimated effort-cost weight</h2>
+          <p>
+            Final interval: <code>[{session.wLower.toFixed(2)}, {session.wUpper.toFixed(2)}]</code>.
+            Point estimate: <code>ŵ = {wMid.toFixed(2)}</code>.
+          </p>
+          {params && (
+            <>
+              <h3>RL params (stub)</h3>
+              <ul>
+                <li><strong>alphaPlus</strong>: {params.alphaPlus}</li>
+                <li><strong>alphaMinus</strong>: {params.alphaMinus}</li>
+                <li><strong>beta</strong>: {params.beta}</li>
+                <li><strong>kappa</strong>: {params.kappa}</li>
+              </ul>
+            </>
+          )}
+          <div style={{display:'flex', gap:'.75rem', alignItems:'center', marginTop:'.5rem'}}>
+            <button className="btn primary" onClick={reset}>Play again</button>
+            <small style={{opacity:.7}}>Finished in {(session.finishedAt! - session.startedAt)/1000 || 0}s</small>
+          </div>
+        </section>
+      )}
+
+      <section className="card">
+        <h2>Notes</h2>
+        <ul>
+          <li>Utility model: choose Hard if <code>R_h - w_E·E_h &gt; R_e - w_E·E_e</code>.</li>
+          <li>Each choice tightens bounds on <code>w_E</code> via <code>w*</code>.</li>
+          <li>The confidence bar shrinks with the interval width.</li>
+        </ul>
+      </section>
+    </div>
+  )
+}

--- a/src/routes/task-effort/state.ts
+++ b/src/routes/task-effort/state.ts
@@ -1,0 +1,65 @@
+import type { Offer, SessionData, Trial } from './types'
+
+export type EffortConfig = {
+  nTrials: number
+}
+
+// A small, hand-crafted offer set that quickly tightens bounds on w.
+// Units: reward in arbitrary points, effort in "units" (subjective).
+const OFFER_SET: Array<Omit<Offer, 't'>> = [
+  { Re: 1, Ee: 1, Rh: 2, Eh: 3, wStar: (2-1)/(3-1) }, // 0.5
+  { Re: 1, Ee: 1, Rh: 3, Eh: 4, wStar: (3-1)/(4-1) }, // 0.67
+  { Re: 1, Ee: 1, Rh: 2, Eh: 4, wStar: (2-1)/(4-1) }, // 0.33
+  { Re: 1, Ee: 1, Rh: 3, Eh: 5, wStar: (3-1)/(5-1) }, // 0.5
+  { Re: 1, Ee: 1, Rh: 4, Eh: 5, wStar: (4-1)/(5-1) }, // 0.75
+  { Re: 1, Ee: 1, Rh: 2.5, Eh: 3, wStar: (2.5-1)/(3-1) }, // 0.75
+  { Re: 1, Ee: 1, Rh: 2, Eh: 5, wStar: (2-1)/(5-1) }, // 0.25
+  { Re: 1, Ee: 1, Rh: 3.5, Eh: 4, wStar: (3.5-1)/(4-1) }, // 0.83
+]
+
+export function makeSession(cfg: EffortConfig): SessionData {
+  return {
+    task: 'effort',
+    trials: [],
+    startedAt: Date.now(),
+    wLower: 0.0,
+    wUpper: 2.0, // broad initial prior; typical w in [0,1], but allow >1
+    meta: { nTrials: cfg.nTrials }
+  }
+}
+
+export function getOffer(t: number): Offer {
+  const base = OFFER_SET[t % OFFER_SET.length]
+  return { t, ...base }
+}
+
+// Update interval bounds from one choice.
+// If chose HARD: implies w < wStar (utility_hard > utility_easy)
+// If chose EASY: implies w > wStar
+export function updateBounds(wLower: number, wUpper: number, wStar: number, choice: 'EASY' | 'HARD') {
+  if (choice === 'HARD') {
+    return { wLower, wUpper: Math.min(wUpper, wStar) }
+  } else {
+    return { wLower: Math.max(wLower, wStar), wUpper }
+  }
+}
+
+// Apply a choice to the session; returns updated session and next offer (or null if done)
+export function step(session: SessionData, choice: 'EASY'|'HARD', cfg: EffortConfig) {
+  const t = session.trials.length
+  const current = getOffer(t)
+  const { wLower, wUpper } = updateBounds(session.wLower, session.wUpper, current.wStar, choice)
+
+  const trial: Trial = { ...current, choice }
+  const trials = [...session.trials, trial]
+  const nextT = t + 1
+  let finishedAt: number | undefined
+  let nextOffer: Offer | null = null
+  if (nextT >= cfg.nTrials) {
+    finishedAt = Date.now()
+  } else {
+    nextOffer = getOffer(nextT)
+  }
+  const updated: SessionData = { ...session, trials, wLower, wUpper, finishedAt }
+  return { session: updated, nextOffer }
+}

--- a/src/routes/task-effort/types.ts
+++ b/src/routes/task-effort/types.ts
@@ -1,0 +1,25 @@
+export type Choice = 'EASY' | 'HARD'
+
+export type Offer = {
+  t: number
+  Re: number   // reward easy
+  Ee: number   // effort easy
+  Rh: number   // reward hard
+  Eh: number   // effort hard
+  wStar: number // (Rh - Re) / (Eh - Ee)  (indifference threshold)
+}
+
+export type Trial = Offer & {
+  choice?: Choice
+}
+
+export type SessionData = {
+  task: 'effort'
+  trials: Trial[]
+  startedAt: number
+  finishedAt?: number
+  // running interval for w_E (lower/upper bounds consistent with observed choices)
+  wLower: number
+  wUpper: number
+  meta: { nTrials:number }
+}


### PR DESCRIPTION
## Summary
- add typed session models for the effort trade-off task
- implement state helpers to cycle through offers and update the effort-weight interval
- build the Effort route UI to run the task, display progress, and show the running estimate

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0189a5c3883218282d9adc2adb685