### PR TITLE
chore(jspsych-deps): add jsPsych and helper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "da-quickcheck",
       "version": "0.1.0",
       "dependencies": {
+        "jspsych": "^7.3.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.26.2"
@@ -1168,6 +1169,18 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/auto-bind": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-4.0.0.tgz",
+      "integrity": "sha512-Hdw8qdNiqdJ8LqT0iK0sVzkFbzg6fhnQqqfWhBDxcHZvU75+B+ayzTy8x+k5Ix0Y92XOhOUlx74ps+bA6BeYMQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.10",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.10.tgz",
@@ -1378,6 +1391,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/jspsych": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/jspsych/-/jspsych-7.3.4.tgz",
+      "integrity": "sha512-wKJJaJ9wed4AORLVANs0G5MfuU8juKDY/2DrIlnphf/1NEaFYfW7Bt0HyRuQwoalUCkTZDqptn9gi0k++Spkwg==",
+      "license": "MIT",
+      "dependencies": {
+        "auto-bind": "^4.0.0",
+        "random-words": "^1.1.1",
+        "seedrandom": "^3.0.5"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -1467,6 +1491,15 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/random-words": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/random-words/-/random-words-1.3.0.tgz",
+      "integrity": "sha512-brwCGe+DN9DqZrAQVNj1Tct1Lody6GrYL/7uei5wfjeQdacFyFd2h/51LNlOoBMzIKMS9xohuL4+wlF/z1g/xg==",
+      "license": "MIT",
+      "dependencies": {
+        "seedrandom": "^3.0.5"
       }
     },
     "node_modules/react": {
@@ -1586,6 +1619,12 @@
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "node_modules/seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,11 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "typecheck": "tsc -b"
   },
   "dependencies": {
+    "jspsych": "^7.3.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.26.2"

--- a/src/lib/jspsych.ts
+++ b/src/lib/jspsych.ts
@@ -1,0 +1,82 @@
+import { initJsPsych } from "jspsych";
+
+type JsPsychInstance = ReturnType<typeof initJsPsych>;
+
+export type JsPsychRunResult = {
+  data: Record<string, unknown>[];
+  startedAt: number;
+  finishedAt: number;
+  taskName: string;
+};
+
+export type RunJsPsychOptions = {
+  taskName: string;
+};
+
+export type JsPsychInitializer = (
+  jsPsych: JsPsychInstance,
+  container: HTMLElement
+) => Promise<void> | void;
+
+export async function runJsPsych(
+  init: JsPsychInitializer,
+  container: HTMLElement,
+  options: RunJsPsychOptions
+): Promise<JsPsychRunResult> {
+  if (!(container instanceof HTMLElement)) {
+    throw new Error("A valid container HTMLElement must be provided to runJsPsych");
+  }
+
+  const { taskName } = options;
+  if (!taskName) {
+    throw new Error("runJsPsych requires a non-empty taskName option");
+  }
+  container.replaceChildren();
+
+  const startedAt = Date.now();
+  let finishedAt = startedAt;
+
+  let resolveFinish: (() => void) | undefined;
+  const finished = new Promise<void>((resolve) => {
+    resolveFinish = resolve;
+  });
+
+  const jsPsych = initJsPsych({
+    display_element: container,
+    on_finish: () => {
+      finishedAt = Date.now();
+      resolveFinish?.();
+    },
+  });
+
+  jsPsych.data.addProperties({ taskName, startedAt });
+
+  await init(jsPsych, container);
+
+  await finished;
+
+  const data = jsPsych
+    .data
+    .get()
+    .values()
+    .map((entry) => ({
+      ...entry,
+      taskName,
+      startedAt,
+      finishedAt,
+    }));
+
+  container.replaceChildren();
+
+  const destroy = (jsPsych as { destroy?: () => void }).destroy;
+  if (typeof destroy === "function") {
+    destroy.call(jsPsych);
+  }
+
+  return {
+    data,
+    startedAt,
+    finishedAt,
+    taskName,
+  };
+}


### PR DESCRIPTION
## Summary
- add the jspsych dependency and expose a typecheck npm script
- create a shared jsPsych runner that handles mounting, metadata, and data export

## Testing
- npm run build
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e175e928d88321b73f1e2ef8726fb2